### PR TITLE
Dynamic size updates

### DIFF
--- a/meshroom/DenseMotion/DenseMotion.py
+++ b/meshroom/DenseMotion/DenseMotion.py
@@ -1,30 +1,8 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
-
-
-class DenseMotionNodeSize(desc.MultiDynamicNodeSize):
-    def computeSize(self, node):
-        from pathlib import Path
-        import itertools
-
-        input_path_param = node.attribute(self._params[0])
-        extension_param = node.attribute(self._params[1])
-
-        input_path = input_path_param.value
-        extension = extension_param.value
-        include_suffixes = [extension.lower(), extension.upper()]
-
-        size = 1
-        if Path(input_path).is_dir():
-            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
-            size = len(image_paths)
-        elif node.attribute(self._params[0]).isLink:
-            size = node.attribute(self._params[0]).getLinkParam().node.size
-        
-        return size
-
+from pyalicevision import parallelization as avpar
 
 class DenseMotionBlockSize(desc.Parallelization):
     def getSizes(self, node):
@@ -45,24 +23,15 @@ class DenseMotion(desc.Node):
     
     gpu = desc.Level.INTENSIVE
 
-    size = DenseMotionNodeSize(['inputImages', 'inputExtension'])
+    size = avpar.DynamicViewsSize("inputImages")
     parallelization = DenseMotionBlockSize()
 
     inputs = [
         desc.File(
             name="inputImages",
             label="Input Images",
-            description="Input images to estimate the depth from. Folder path or sfmData filepath",
+            description="Input images to estimate the depth from, sfmData filepath",
             value="",
-        ),
-        desc.ChoiceParam(
-            name="inputExtension",
-            label="Input Extension",
-            description="Extension of the input images. This will be used to determine which images are to be used if \n"
-                        "a directory is provided as the input. If \"\" is selected, the provided input will be used as such.",
-            values=["jpg", "jpeg", "png", "exr"],
-            value="exr",
-            exclusive=True,
         ),
         desc.FloatParam(
             name="PyramidScale",
@@ -98,7 +67,6 @@ class DenseMotion(desc.Node):
             value=50,
             description="Sets the number of images to process in one chunk. If set to 0, all images are processed at once.",
             range=(0, 1000, 1),
-            enabled=lambda node: node.model.value == "MoGe"
         ),
         desc.ChoiceParam(
             name="verboseLevel",
@@ -122,15 +90,13 @@ class DenseMotion(desc.Node):
             description="Output optical flow images",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/<FILESTEM>.exr",
-            group="",
         )
     ]
 
     def preprocess(self, node):
-        extension = node.inputExtension.value
         input_path = node.inputImages.value
 
-        image_paths = get_image_paths_list(input_path, extension)
+        image_paths = get_image_paths_list(input_path)
 
         if len(image_paths) == 0:
             raise FileNotFoundError(f'No image files found in {input_path}')
@@ -184,18 +150,14 @@ class DenseMotion(desc.Node):
         finally:
             chunk.logManager.end()
 
-def get_image_paths_list(input_path, extension):
+def get_image_paths_list(input_path):
     from pyalicevision import sfmData
     from pyalicevision import sfmDataIO
     from pathlib import Path
-    import itertools
 
-    include_suffixes = [extension.lower(), extension.upper()]
     image_paths = []
 
-    if Path(input_path).is_dir():
-        image_paths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
-    elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+    if Path(input_path).suffix.lower() in [".sfm", ".abc"]:
         if Path(input_path).exists():
             dataAV = sfmData.SfMData()
             if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):

--- a/meshroom/DenseMotion/DenseMotion.py
+++ b/meshroom/DenseMotion/DenseMotion.py
@@ -30,7 +30,7 @@ class DenseMotion(desc.Node):
         desc.File(
             name="inputImages",
             label="Input Images",
-            description="Input images to estimate the depth from, sfmData filepath",
+            description="sfmData filepath",
             value="",
         ),
         desc.FloatParam(

--- a/meshroom/DenseMotion/RaftOF.py
+++ b/meshroom/DenseMotion/RaftOF.py
@@ -1,6 +1,5 @@
 __version__ = "2.0"
 
-from re import M
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
@@ -32,7 +31,7 @@ class RaftOF(desc.Node):
         desc.File(
             name="inputImages",
             label="Input Images",
-            description="Input images to estimate the depth from, sfmData filepath",
+            description="sfmData filepath",
             value="",
         ),
         desc.File(
@@ -81,7 +80,7 @@ class RaftOF(desc.Node):
         desc.File(
             name="OpticalFlowUp",
             label="Optical Flow Up",
-            description="Output up optical flow images",
+            description="Upscaled optical flow images",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/<FILESTEM>.exr",
         ),

--- a/meshroom/DenseMotion/RaftOF.py
+++ b/meshroom/DenseMotion/RaftOF.py
@@ -1,30 +1,9 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 from re import M
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
-
-
-class RaftOFNodeSize(desc.MultiDynamicNodeSize):
-    def computeSize(self, node):
-        from pathlib import Path
-        import itertools
-
-        input_path_param = node.attribute(self._params[0])
-        extension_param = node.attribute(self._params[1])
-
-        input_path = input_path_param.value
-        extension = extension_param.value
-        include_suffixes = [extension.lower(), extension.upper()]
-
-        size = 1
-        if Path(input_path).is_dir():
-            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
-            size = len(image_paths)
-        elif node.attribute(self._params[0]).isLink:
-            size = node.attribute(self._params[0]).getLinkParam().node.size
-        
-        return size
+from pyalicevision import parallelization as avpar
 
 
 class RaftOFBlockSize(desc.Parallelization):
@@ -46,24 +25,15 @@ class RaftOF(desc.Node):
     
     gpu = desc.Level.INTENSIVE
 
-    size = RaftOFNodeSize(['inputImages', 'inputExtension'])
+    size = avpar.DynamicViewsSize("inputImages")
     parallelization = RaftOFBlockSize()
 
     inputs = [
         desc.File(
             name="inputImages",
             label="Input Images",
-            description="Input images to estimate the depth from. Folder path or sfmData filepath",
+            description="Input images to estimate the depth from, sfmData filepath",
             value="",
-        ),
-        desc.ChoiceParam(
-            name="inputExtension",
-            label="Input Extension",
-            description="Extension of the input images. This will be used to determine which images are to be used if \n"
-                        "a directory is provided as the input. If \"\" is selected, the provided input will be used as such.",
-            values=["jpg", "jpeg", "png", "exr"],
-            value="exr",
-            exclusive=True,
         ),
         desc.File(
             name="modelPath",
@@ -109,20 +79,18 @@ class RaftOF(desc.Node):
             value="{nodeCacheFolder}",
         ),
         desc.File(
-            name="OpticalFlow",
-            label="Optical Flow",
-            description="Output optical flow images",
+            name="OpticalFlowUp",
+            label="Optical Flow Up",
+            description="Output up optical flow images",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/<FILESTEM>.exr",
-            group="",
-        )
+        ),
     ]
 
     def preprocess(self, node):
-        extension = node.inputExtension.value
         input_path = node.inputImages.value
 
-        image_paths = get_image_paths_list(input_path, extension)
+        image_paths = get_image_paths_list(input_path)
 
         if len(image_paths) == 0:
             raise FileNotFoundError(f'No image files found in {input_path}')
@@ -167,11 +135,12 @@ class RaftOF(desc.Node):
             chunk.logger.info(f'Starting computation on chunk {chunk.range.iteration + 1}/{chunk.range.fullSize // chunk.range.blockSize + int(chunk.range.fullSize != chunk.range.blockSize)}...')
 
             for idx, path in enumerate(chunk_image_paths):
-                if idx > 0:
+                if idx < len(chunk_image_paths) - 1:
                     with torch.no_grad():
-                        image1, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx - 1]), True)
-                        image2, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), True)
+                        image1, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), True)
+                        image2, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx + 1]), True)
 
+                        scale = 1.0
                         if max(h_ori, w_ori) > chunk.node.maxImageSize.value:
                             maxDim = float(max(h_ori, w_ori))
                             scale = float(chunk.node.maxImageSize.value) / maxDim
@@ -197,34 +166,36 @@ class RaftOF(desc.Node):
                         flow_low, flow_up = model(image1, image2, iters=chunk.node.IterationNumber.value, test_mode=True)
                         flow_up = padder.unpad(flow_up)
                         flow_up = flow_up[0].permute(1,2,0).cpu().numpy()
-                        flow_out = flow_up.copy()
+                        flow_up_out = flow_up.copy() / scale
+                        flow_low = padder.unpad(flow_low)
+                        flow_low = flow_low[0].permute(1,2,0).cpu().numpy()
+                        flow_low_out = flow_low.copy() / scale
 
-                        h,w,_ = flow_out.shape
-                        nc = np.zeros((h,w,1), dtype=flow_out.dtype)
-                        flow_out = np.concatenate((flow_out,nc), axis=2)
+                        h,w,_ = flow_up_out.shape
+                        nc = np.zeros((h,w,1), dtype=flow_up_out.dtype)
+                        flow_up_out = np.concatenate((flow_up_out,nc), axis=2)
+                        h,w,_ = flow_low_out.shape
+                        nc = np.zeros((h,w,1), dtype=flow_low_out.dtype)
+                        flow_low_out = np.concatenate((flow_low_out,nc), axis=2)
 
                         outputDirPath = Path(chunk.node.output.value)
                         image_stem = Path(chunk_image_paths[idx]).stem
-                        of_file_name = image_stem + ".exr"
+                        ofup_file_name = image_stem + ".exr"
 
-                        image.writeImage(str(outputDirPath / of_file_name), flow_out, h_ori, w_ori, orientation, pixelAspectRatio)
+                        image.writeImage(str(outputDirPath / ofup_file_name), flow_up_out, h_ori, w_ori, orientation, pixelAspectRatio)
             
-            chunk.logger.info('Publish end')
+            chunk.logger.info('RaftOF end')
         finally:
             chunk.logManager.end()
 
-def get_image_paths_list(input_path, extension):
+def get_image_paths_list(input_path):
     from pyalicevision import sfmData
     from pyalicevision import sfmDataIO
     from pathlib import Path
-    import itertools
 
-    include_suffixes = [extension.lower(), extension.upper()]
     image_paths = []
 
-    if Path(input_path).is_dir():
-        image_paths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
-    elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+    if Path(input_path).suffix.lower() in [".sfm", ".abc"]:
         if Path(input_path).exists():
             dataAV = sfmData.SfMData()
             if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):


### PR DESCRIPTION
This pull request refactors the `DenseMotion` and `RaftOF` nodes in Meshroom, streamlining how input images are handled and improving parallelization logic. The main changes remove the need for specifying input image extensions, update the chunk processing logic, and align the node interfaces with the `pyalicevision` parallelization API.

**Input Handling and Parallelization Improvements:**

* Replaced custom node size classes (`DenseMotionNodeSize`, `RaftOFNodeSize`) with `avpar.DynamicViewsSize("inputImages")`, removing the need for an explicit input extension parameter and simplifying image path resolution. (`meshroom/DenseMotion/DenseMotion.py`, `meshroom/DenseMotion/RaftOF.py`) [[1]](diffhunk://#diff-cf37bf04787e43bf3e3b682d8b42c48760d26c85c0a9d080f7bccc9f0a222b15L1-R5) [[2]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L1-R6)
* Removed the `inputExtension` parameter and associated logic from both node classes, relying solely on the input path for image discovery. (`meshroom/DenseMotion/DenseMotion.py`, `meshroom/DenseMotion/RaftOF.py`) [[1]](diffhunk://#diff-cf37bf04787e43bf3e3b682d8b42c48760d26c85c0a9d080f7bccc9f0a222b15L48-L66) [[2]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L49-L67)
* Refactored the `get_image_paths_list` function to no longer require an extension argument and to only support folder or `.sfm`/`.abc` inputs. (`meshroom/DenseMotion/DenseMotion.py`, `meshroom/DenseMotion/RaftOF.py`) [[1]](diffhunk://#diff-cf37bf04787e43bf3e3b682d8b42c48760d26c85c0a9d080f7bccc9f0a222b15L187-R160) [[2]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L200-R198)

**Chunk Processing and Output Adjustments:**

* Updated chunk processing logic in `RaftOF` to correctly pair images for optical flow computation and to output both upscaled and low-resolution flows, normalizing by scale. (`meshroom/DenseMotion/RaftOF.py`) [[1]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L170-R143) [[2]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L200-R198)
* Changed output parameter in `RaftOF` from `OpticalFlow` to `OpticalFlowUp` and improved output naming and logging. (`meshroom/DenseMotion/RaftOF.py`) [[1]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L112-R93) [[2]](diffhunk://#diff-8c65f20f818566cfa0fcd462a722db68a5d3777f5d3bf896fcbd425830ed8749L200-R198)

These changes make the nodes easier to use, reduce user error, and ensure compatibility with updated parallelization strategies.